### PR TITLE
Fix LMA shutdown and cable disconnection

### DIFF
--- a/src/main/kotlin/com/muxiu1997/mxrandom/metatileentity/MTELargeMolecularAssembler.kt
+++ b/src/main/kotlin/com/muxiu1997/mxrandom/metatileentity/MTELargeMolecularAssembler.kt
@@ -419,17 +419,16 @@ class MTELargeMolecularAssembler :
           if (getProxy()?.getNode()?.getPlayerID() == -1) {
 
             MXRandom.logger.warn(
-                "Found a LMA at [${(getBaseMetaTileEntity() as BaseMetaTileEntity).getLocation().toString()}] without valid AE playerID.")
+                "Found a LMA at [${(baseMetaTileEntity as BaseMetaTileEntity).getLocation().toString()}] without valid AE playerID.")
             MXRandom.logger.warn(
-                "Try to recover playerID with UUID:${getBaseMetaTileEntity().getOwnerUuid()}")
+                "Try to recover playerID with UUID:${baseMetaTileEntity.getOwnerUuid()}")
             // recover ID from old version
             var playerAEID =
                 WorldData.instance()
                     .playerData()
                     .getPlayerID(
                         com.mojang.authlib.GameProfile(
-                            getBaseMetaTileEntity().getOwnerUuid(),
-                            getBaseMetaTileEntity().getOwnerName()))
+                            baseMetaTileEntity.getOwnerUuid(), baseMetaTileEntity.getOwnerName()))
 
             getProxy()?.getNode()?.setPlayerID(playerAEID)
             var node = getProxy()?.getNode() as GridNode?


### PR DESCRIPTION
Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18127
Bug：LMA shutdown instantly and disconnect the cable if a Security Terminal（even it belongs to the same person owns the LMA） is present
<details>
<summary>Expand</summary>
<p>

https://github.com/user-attachments/assets/389085ef-ccff-4ecb-a9a5-e4878c6e7318
</p>
</details>

This bug can be workarounded by connecting the LMA with a network **without** Security Terminal, then merge it to a network **with** Security Terminal.
Depending on the order of chunk loading, this trick might be done automatically.
This is caused by LMA not having proper owner setting, and forcing a Node with wrong setting to join a network with Security Terminal might have some potential problems.

LMA made 2 mistakes when using AE API:

1.LMA does not call setOwner when block placed by user
This makes LMA has no owner, so it's rejected by Security Terminal.
LMA truns off when it's rejected, which can be seen in the video.
And it disconnects all calbles when it's off(also see video).

2.LMA use AENetworkProxy.invalidate()/onReady() to temporarily trun off/on the machine
invalidate() is not for truning off a AE Machine, it's to clean up when chunk is unloaded
invalidate() also destroy the node, which contains owner info, so even if owner recorded, LMA will lost it after machine reboots

<details>
<summary>Expand</summary>
<p>

![a](https://github.com/user-attachments/assets/47e75f6b-00ab-4042-9dc7-c2044fd07478)
</p>
</details>

This PR fix those 2 problems by:
1. call setOwner, just like CraftingInput(ME) and OutputBus(ME) do. 
2. add code to save/load AENetworkProxy to/from NBT, just like CraftingInput(ME) and OutputBus(ME) do. 
3. use setValidSides instead of invalidate() /onReady() to cut/establish cable connection when turn off/on
4. Recover owner setting of AENetworkProxy(by UUID stored in BaseMetaTileEntity) if such setting is missing, to make it compatible with old version.

will get this on console when loading  an old world with old LMA
```
[21:01:36] [Server thread/WARN] [mxrandom]: Found a LMA at [dimension=0, x=-116, y=6, z=383] without valid AE playerID.
[21:01:36] [Server thread/WARN] [mxrandom]: Try to recover playerID with UUID:2a579636-dca3-4175-a20d-b280ae743cda
[21:01:36] [Server thread/WARN] [mxrandom]: Now it has playerID:[2]

```
test video
LMA is now correctly rejected by network that has no access to(before PR, this can be bypassed with the trick listed above)
LMA is now correctly accepted by friendly network (before PR, LMA might be rejected after you reboot the machine)
https://github.com/user-attachments/assets/e489e124-2069-4b00-aafd-39fd9d15a6cf


