### PR TITLE
Add LMA recipe back

### DIFF
--- a/src/main/java/com/muxiu1997/mxrandom/loader/RecipeLoader.java
+++ b/src/main/java/com/muxiu1997/mxrandom/loader/RecipeLoader.java
@@ -1,27 +1,26 @@
 package com.muxiu1997.mxrandom.loader;
 
+import static gregtech.api.enums.Mods.AppliedEnergistics2;
 import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
+import static gregtech.api.util.GTModHandler.getModItem;
+import static gregtech.api.util.GTRecipeBuilder.SECONDS;
+
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
-import gregtech.api.enums.TierEU;
-import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import gregtech.api.enums.Materials;
-import static gregtech.api.util.GTModHandler.getModItem;
-import static gregtech.api.enums.Mods.AppliedEnergistics2;
+import gregtech.api.enums.TierEU;
 
 public class RecipeLoader {
 
     public static void load() {
-      GTValues.RA.stdBuilder()
-        .itemInputs(
-          getModItem(AppliedEnergistics2.ID, "tile.BlockInterface", 8, 0),
-          getModItem(AppliedEnergistics2.ID, "tile.BlockMolecularAssembler", 8, 0),
-          ItemList.Emitter_IV.get(4L),
-          ItemList.Casing_RobustTungstenSteel.get(1L))
-        .itemOutputs(GTMetaTileEntityLoader.largeMolecularAssembler.getStackForm(1))
-        .fluidInputs(Materials.Plastic.getMolten(1296))
-        .duration(60 * SECONDS)
-        .eut(TierEU.RECIPE_IV)
-        .addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(AppliedEnergistics2.ID, "tile.BlockInterface", 8, 0),
+                        getModItem(AppliedEnergistics2.ID, "tile.BlockMolecularAssembler", 8, 0),
+                        ItemList.Emitter_IV.get(4L),
+                        ItemList.Casing_RobustTungstenSteel.get(1L))
+                .itemOutputs(GTMetaTileEntityLoader.largeMolecularAssembler.getStackForm(1))
+                .fluidInputs(Materials.Plastic.getMolten(1296)).duration(60 * SECONDS).eut(TierEU.RECIPE_IV)
+                .addTo(assemblerRecipes);
     }
 }

--- a/src/main/java/com/muxiu1997/mxrandom/loader/RecipeLoader.java
+++ b/src/main/java/com/muxiu1997/mxrandom/loader/RecipeLoader.java
@@ -1,6 +1,27 @@
 package com.muxiu1997.mxrandom.loader;
 
+import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
+import gregtech.api.enums.GTValues;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.TierEU;
+import static gregtech.api.util.GTRecipeBuilder.SECONDS;
+import gregtech.api.enums.Materials;
+import static gregtech.api.util.GTModHandler.getModItem;
+import static gregtech.api.enums.Mods.AppliedEnergistics2;
+
 public class RecipeLoader {
 
-    public static void load() {}
+    public static void load() {
+      GTValues.RA.stdBuilder()
+        .itemInputs(
+          getModItem(AppliedEnergistics2.ID, "tile.BlockInterface", 8, 0),
+          getModItem(AppliedEnergistics2.ID, "tile.BlockMolecularAssembler", 8, 0),
+          ItemList.Emitter_IV.get(4L),
+          ItemList.Casing_RobustTungstenSteel.get(1L))
+        .itemOutputs(GTMetaTileEntityLoader.largeMolecularAssembler.getStackForm(1))
+        .fluidInputs(Materials.Plastic.getMolten(1296))
+        .duration(60 * SECONDS)
+        .eut(TierEU.RECIPE_IV)
+        .addTo(assemblerRecipes);
+    }
 }


### PR DESCRIPTION
Adds the Large Molecular Assembler Controller recipe, It is the same as before the removal, but with reduced duration

![kép](https://github.com/user-attachments/assets/8afccade-1d68-4027-871d-a1200f1edd82)
